### PR TITLE
Remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     }
   ],
   "main": "./lib/index",
-  "engines": {
-    "node": "~0.6.10 || 0.8 || 0.9 || 4.x || 5.x || 6.x"
-  },
   "scripts": {
     "prepublish": "coffee -c -o lib/ src/",
     "postinstall": "node setup.js postinstall",


### PR DESCRIPTION
This is forcing me to use `yarn --ignore-engines`. If you would like to add something like `"node": ">= 0.6"` instead of removing it, that should also work, but I don't see much point to keeping the field on this anymore.

Thanks.